### PR TITLE
Fixed font family on the SideDrawer element inside the Header component

### DIFF
--- a/src/components/SideDrawer/index.css
+++ b/src/components/SideDrawer/index.css
@@ -8,6 +8,7 @@
   font-size: 30px;
   display: block;
   text-align: center;
+  font-family: "Righteous", cursive;
 }
 
 .drawer .drawer__item:hover {


### PR DESCRIPTION
**Overview**
The font family was not the correct one on the SideDrawer element inside the Header component.